### PR TITLE
Add fade in/out animation

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,15 +8,41 @@ jokes = [
     "Why did the scarecrow win an award? He was outstanding in his field!"
 ]
 
+fade_steps = 20
+
+def fade_in(step=0):
+    color_value = 255 - int(step * 255 / fade_steps)
+    hex_color = f"#{color_value:02x}{color_value:02x}{color_value:02x}"
+    label.config(fg=hex_color)
+    if step < fade_steps:
+        label.after(30, fade_in, step + 1)
+
+def fade_out(step=0, new_text=""):
+    color_value = int(step * 255 / fade_steps)
+    hex_color = f"#{color_value:02x}{color_value:02x}{color_value:02x}"
+    label.config(fg=hex_color)
+    if step < fade_steps:
+        label.after(30, fade_out, step + 1, new_text)
+    else:
+        if new_text:
+            label.config(text=new_text)
+            fade_in()
+
 def tell_joke():
     joke = random.choice(jokes)
-    label.config(text=joke)
+    fade_out(new_text=joke)
 
 root = tk.Tk()
 root.title("Random Joke Generator")
 root.geometry("400x200")
 
-label = tk.Label(root, text="Click the button for a joke!", wraplength=380, justify="center", font=("Arial", 12))
+label = tk.Label(
+    root,
+    text="Click the button for a joke!",
+    wraplength=380,
+    justify="center",
+    font=("Arial", 12),
+)
 label.pack(pady=20)
 
 button = tk.Button(root, text="Tell me a joke", command=tell_joke)


### PR DESCRIPTION
## Summary
- add fade_in and fade_out helpers to animate the joke text
- refactor label definition for readability

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_688a9843d7ec8324ab257f1bdb24a63e